### PR TITLE
Handle YouTube share links with extra params

### DIFF
--- a/tests/test_normalize_url.py
+++ b/tests/test_normalize_url.py
@@ -1,0 +1,17 @@
+import youtube_downloader as yd
+
+
+def test_short_url_si_param_removed():
+    url = "https://youtu.be/nw8kLJoMUMw?si=GiAjA4L1LoFjsqpl"
+    assert yd.normalize_url(url) == "https://youtu.be/nw8kLJoMUMw"
+
+
+def test_watch_url_si_param_removed():
+    url = "https://www.youtube.com/watch?v=nw8kLJoMUMw&si=abc"
+    assert yd.normalize_url(url) == "https://www.youtube.com/watch?v=nw8kLJoMUMw"
+
+
+def test_watch_url_preserves_other_params():
+    url = "https://www.youtube.com/watch?v=nw8kLJoMUMw&t=30s&si=abc"
+    expected = "https://www.youtube.com/watch?v=nw8kLJoMUMw&t=30s"
+    assert yd.normalize_url(url) == expected

--- a/youtube_downloader.py
+++ b/youtube_downloader.py
@@ -5,7 +5,20 @@ import time
 from pathlib import Path
 import tkinter as tk
 from tkinter import ttk, filedialog, messagebox
+from urllib.parse import parse_qsl, urlencode, urlparse, urlunparse
 from pytube import YouTube
+
+
+def normalize_url(url: str) -> str:
+    """Return YouTube link stripped of unnecessary query parameters."""
+    parsed = urlparse(url)
+    netloc = parsed.netloc.lower()
+    if netloc in ("youtu.be", "www.youtu.be"):
+        return urlunparse(parsed._replace(query=""))
+    if netloc.endswith("youtube.com"):
+        qs = [(k, v) for k, v in parse_qsl(parsed.query) if k != "si"]
+        return urlunparse(parsed._replace(query=urlencode(qs)))
+    return url
 
 
 class YouTubeDownloader(tk.Tk):
@@ -112,7 +125,7 @@ class YouTubeDownloader(tk.Tk):
     # -------------------------------------------------------------
     def fetch_info(self) -> None:
         """Validate URL and populate quality options."""
-        url = self.url_var.get().strip()
+        url = normalize_url(self.url_var.get().strip())
         if not url:
             return
         try:


### PR DESCRIPTION
## Summary
- normalize pasted YouTube URLs by removing non-essential query parameters
- use the normalized URL when validating links
- add tests covering short and watch URLs with extra parameters

## Testing
- `python -m pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68978f8c7544832e8444d4aa6397cdf4